### PR TITLE
chore: pin actions/checkout to v6.0.2 (commit SHA)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- Pins `actions/checkout` to commit `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) across all workflows
- Replaces the previous floating `@v4` tag reference

## Why
- **Supply-chain hardening**: a floating tag can be re-pointed by a compromised maintainer; a SHA cannot
- **v6 changes**: Node 24 runtime (requires runner v2.327.1+, which `ubuntu-latest` already has) and credential isolation (creds persisted to a separate file via includeIf rather than into `.git/config`)

## Test plan
- [ ] CI runs successfully on this PR
- [ ] (sdk-execution only) version-tag push step succeeds on next release

Release notes: https://github.com/actions/checkout/releases/tag/v6.0.2
Commit: https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd